### PR TITLE
Wrong folder name in crontab entry

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ while true; do
 		while true; do
 			read -p "Do you want to setup a Cron Job? (Y/N)" continue
 			if [ $continue == "Y" ] || [ $continue == "y" ]; then
-				crontab -l | { cat; echo "0 0 * * * /scipts/autoBackup.sh"; } | crontab -
+				crontab -l | { cat; echo "0 0 * * * /scripts/autoBackup.sh"; } | crontab -
 				echo "Fully setup AutoBackup For Pterodactyl, exiting!"
 				exit 1
 			elif [ $continue == "N" ] || [ $continue == "n" ]; then


### PR DESCRIPTION
In the crontab entry, 'scipts' should be 'scripts'.